### PR TITLE
Remove rpc credentials and add link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Credit [Notmandatory](https://github.com/notmandatory/) and the [BDK team](https
 alias rt-start='docker run -d --rm -p 127.0.0.1:18443-18444:18443-18444/tcp -p 127.0.0.1:60401:60401/tcp --name electrs bitcoindevkit/electrs'
 alias rt-stop='docker kill electrs'
 alias rt-logs='docker container logs electrs'
-alias rt-cli='docker exec -it electrs /root/bitcoin-cli -regtest -rpcuser=admin -rpcpassword=passw $@'
+alias rt-cli='docker exec -it electrs /root/bitcoin-cli -regtest $@'
 ```
 
 #### 3. Use REGTEST aliases to start container, view logs, run cli command, stop container

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ rt-cli getnewaddress
 rt-stop
 ```
 
-#### 4. Jump straight to chapter 3.2 of `Learning Bitcoin from the Commandline`
+#### 4. Jump straight to chapter 3.2 of [`Learning Bitcoin from the Commandline`](https://github.com/BlockchainCommons/Learning-Bitcoin-from-the-Command-Line/blob/master/03_2_Knowing_Your_Bitcoin_Setup.md)
 Replace all instances of `bitcoin-cli` with `rt-cli`. For example:
 
 ```


### PR DESCRIPTION
It looks like those rpc credentials used don't work anymore with the latest image version. I also added a link to the chapter mentioned in one of the titles